### PR TITLE
Bug fixes: SSL, redundant HTTP redirect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ LABEL maintainer "mch1307@gmail.com"
 ENV SERVICE_NAME=traefik \
     SERVICE_HOME=/opt/traefik \
     SERVICE_VERSION=v1.3.6 \
-    SERVICE_URL=https://github.com/containous/traefik/releases/download 
+    SERVICE_URL=https://github.com/containous/traefik/releases/download
 ENV SERVICE_RELEASE=${SERVICE_URL}/${SERVICE_VERSION}/traefik_linux-amd64 \
     PATH=${PATH}:${SERVICE_HOME}/bin
 
 # Download and install traefik
 RUN mkdir -p ${SERVICE_HOME}/bin ${SERVICE_HOME}/etc ${SERVICE_HOME}/log ${SERVICE_HOME}/certs ${SERVICE_HOME}/acme && \
-    apk add --no-cache bash curl  && \
+    apk add --no-cache bash curl ca-certificates && \
     cd ${SERVICE_HOME}/bin && \
     curl -jksSL "${SERVICE_RELEASE}" -O && \
     mv traefik_linux-amd64 traefik && \
@@ -20,7 +20,7 @@ RUN mkdir -p ${SERVICE_HOME}/bin ${SERVICE_HOME}/etc ${SERVICE_HOME}/log ${SERVI
     apk del curl
 ADD opt /
 RUN chmod +x ${SERVICE_HOME}/bin/*.sh && \
-    chmod +x ${SERVICE_HOME}/bin/traefik 
+    chmod +x ${SERVICE_HOME}/bin/traefik
 EXPOSE 8000
 EXPOSE 80
 EXPOSE 443

--- a/opt/opt/traefik/bin/traefik.toml.sh
+++ b/opt/opt/traefik/bin/traefik.toml.sh
@@ -28,6 +28,8 @@ TRAEFIK_ENTRYPOINTS_HTTP="\
 "
 
 
+if [ "X${TRAEFIK_ACME_ENABLE}" == "Xfalse" ]; then
+
 TRAEFIK_ENTRYPOINTS_HTTPS="\
   [entryPoints.https]
     address = \":${TRAEFIK_HTTPS_PORT}\"
@@ -38,13 +40,23 @@ TRAEFIK_ENTRYPOINTS_HTTPS="\
         keyFile = \"$TRAEFIK_SSL_PRIVATE_KEY\"
 "
 
+else
+
+TRAEFIK_ENTRYPOINTS_HTTPS="\
+  [entryPoints.https]
+    address = \":${TRAEFIK_HTTPS_PORT}\"
+    [entryPoints.https.tls]
+"
+
+fi
+
+
+
 if [ "X${TRAEFIK_HTTPS_ENABLE}" == "Xtrue" ]; then
     TRAEFIK_ENTRYPOINTS_OPTS=${TRAEFIK_ENTRYPOINTS_HTTP}${TRAEFIK_ENTRYPOINTS_HTTPS}
     TRAEFIK_ENTRYPOINTS='"http", "https"'
 elif [ "X${TRAEFIK_HTTPS_ENABLE}" == "Xonly" ]; then
     TRAEFIK_ENTRYPOINTS_HTTP=$TRAEFIK_ENTRYPOINTS_HTTP"\
-    [entryPoints.http.redirect]
-       entryPoint = \"https\"
 "
     TRAEFIK_ENTRYPOINTS_OPTS=${TRAEFIK_ENTRYPOINTS_HTTP}${TRAEFIK_ENTRYPOINTS_HTTPS}
     TRAEFIK_ENTRYPOINTS='"http", "https"'

--- a/opt/opt/traefik/bin/traefik.toml.sh
+++ b/opt/opt/traefik/bin/traefik.toml.sh
@@ -22,20 +22,20 @@ TRAEFIK_RANCHER_SECRET_KEY=$(cat $TRAEFIK_RANCHER_SECRET && echo)
 
 TRAEFIK_ENTRYPOINTS_HTTP="\
   [entryPoints.http]
-  address = \":${TRAEFIK_HTTP_PORT}\"
+    address = \":${TRAEFIK_HTTP_PORT}\"
     [entryPoints.http.redirect]
-    entryPoint = \"https\"
+      entryPoint = \"https\"
 "
 
 
 TRAEFIK_ENTRYPOINTS_HTTPS="\
   [entryPoints.https]
-  address = \":${TRAEFIK_HTTPS_PORT}\"
+    address = \":${TRAEFIK_HTTPS_PORT}\"
     [entryPoints.https.tls]"
        TRAEFIK_ENTRYPOINTS_HTTPS=$TRAEFIK_ENTRYPOINTS_HTTPS"
       [[entryPoints.https.tls.certificates]]
-      certFile = \"$TRAEFIK_SSL_CERT\" 
-      keyFile = \"$TRAEFIK_SSL_PRIVATE_KEY\" 
+        certFile = \"$TRAEFIK_SSL_CERT\"
+        keyFile = \"$TRAEFIK_SSL_PRIVATE_KEY\"
 "
 
 if [ "X${TRAEFIK_HTTPS_ENABLE}" == "Xtrue" ]; then
@@ -48,7 +48,7 @@ elif [ "X${TRAEFIK_HTTPS_ENABLE}" == "Xonly" ]; then
 "
     TRAEFIK_ENTRYPOINTS_OPTS=${TRAEFIK_ENTRYPOINTS_HTTP}${TRAEFIK_ENTRYPOINTS_HTTPS}
     TRAEFIK_ENTRYPOINTS='"http", "https"'
-else 
+else
     TRAEFIK_ENTRYPOINTS_OPTS=${TRAEFIK_ENTRYPOINTS_HTTP}
     TRAEFIK_ENTRYPOINTS='"http"'
 fi


### PR DESCRIPTION
1) When using the HTTPS variable set to only, it duplicated the `[entryPoints.http.redirect]` as seen below.

```
debug = true
logLevel = "INFO"
traefikLogsFile = "/opt/traefik/log/traefik.log"
accessLogsFile = "/opt/traefik/log/access.log"
defaultEntryPoints = ["http", "https"]
[entryPoints]
[entryPoints.http]
address = ":80"
[entryPoints.http.redirect]
entryPoint = "https"
[entryPoints.http.redirect]
entryPoint = "https"
[entryPoints.https]
address = ":443"
[entryPoints.https.tls]
[[entryPoints.https.tls.certificates]]
certFile = ""
keyFile = ""
```

2) When ACME is enabled, the `[entryPoints.https.tls.certificates]` was still being generated.  Put in an `IF` condition to fix this.

3) Fixed issue where external calls to SSL enabled sites were failing due to the `ca-certificates` bundle not being installed.  Added to the Dockerfile.

4) Format cleanup to follow the other line examples.